### PR TITLE
rest_client has been deprecated. Replace with working alternative

### DIFF
--- a/bittrex.gemspec
+++ b/bittrex.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec'
   spec.add_dependency 'json'
-  spec.add_dependency "rest_client"
+  spec.add_dependency "rest-client"
 end


### PR DESCRIPTION
When I tried to build the gem on my local machine I received this error:

```
Bundler could not find compatible versions for gem "rest_client":
  In Gemfile:
    bittrex was resolved to 1.0.0, which depends on
      rest_client

Could not find gem 'rest_client', which is required by gem 'bittrex', in any of the sources.
```

Turns out that [rest_client](https://github.com/treeder/rest_client) has been deprecated and the suggested alternative is [rest-client](https://github.com/rest-client/rest-client). I've gone ahead and made the change in this gem's dependencies. Everything works fine for me now: quotes, orders etc.